### PR TITLE
Add animated landing page and interactive palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",
+        "gsap": "^3.12.5",
         "quantize": "^1.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -3031,6 +3032,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-redux": "^9.2.0",
-    "tinycolor2": "^1.6.0"
+    "tinycolor2": "^1.6.0",
+    "gsap": "^3.12.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,16 @@
+import { useState } from 'react'
 import ImageUploader from './components/ImageUploader'
 import PalettePreview from './components/PalettePreview'
 import TokenExport from './components/TokenExport'
+import LandingPage from './components/LandingPage'
 
 export default function App() {
+  const [started, setStarted] = useState(false)
+
+  if (!started) {
+    return <LandingPage onStart={() => setStarted(true)} />
+  }
+
   return (
     <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
       <h1>Palette Theme Studio</h1>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,19 +1,23 @@
-import {type ChangeEvent, useCallback } from 'react'
+import { type ChangeEvent, useCallback, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import type {AppDispatch} from '../store'
+import type { AppDispatch } from '../store'
 import { setColors } from '../features/paletteSlice'
 import { extractPalette } from '../utils/palette'
 
 export default function ImageUploader() {
   const dispatch = useDispatch<AppDispatch>()
+  const [preview, setPreview] = useState<string | null>(null)
 
   const handleFile = useCallback(
     async (file: File | null) => {
       if (!file) return
+      if (preview) URL.revokeObjectURL(preview)
+      const url = URL.createObjectURL(file)
+      setPreview(url)
       const colors = await extractPalette(file)
       dispatch(setColors(colors))
     },
-    [dispatch],
+    [dispatch, preview],
   )
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -24,6 +28,13 @@ export default function ImageUploader() {
   return (
     <div>
       <input type="file" accept="image/*" onChange={onChange} />
+      {preview && (
+        <img
+          src={preview}
+          alt="preview"
+          style={{ maxWidth: '300px', marginTop: '1rem', display: 'block' }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+interface LandingPageProps {
+  onStart: () => void
+}
+
+gsap.registerPlugin(ScrollTrigger)
+
+export default function LandingPage({ onStart }: LandingPageProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const sections = gsap.utils.toArray<HTMLElement>(
+      containerRef.current?.querySelectorAll('.panel') ?? [],
+    )
+    if (sections.length === 0) return
+    const totalWidth = window.innerWidth * (sections.length - 1)
+    gsap.to(sections, {
+      xPercent: -100 * (sections.length - 1),
+      ease: 'none',
+      scrollTrigger: {
+        trigger: containerRef.current,
+        pin: true,
+        scrub: 1,
+        snap: 1 / (sections.length - 1),
+        end: () => '+=' + totalWidth,
+      },
+    })
+  }, [])
+
+  const features = [
+    'Drag & Drop изображений для извлечения палитры',
+    'Генерация дизайн-токенов и автоматические оттенки',
+    'Проверка контрастности и подсказки коррекции',
+    'Превью UI-компонентов в светлой и тёмной теме',
+    'Экспорт в CSS variables, Tailwind config и JSON',
+    'Сохранение и загрузка пресетов',
+  ]
+
+  return (
+    <div ref={containerRef} className="landing-container">
+      <div className="landing-sections">
+        {features.map((f) => (
+          <section key={f} className="panel">
+            <div>{f}</div>
+          </section>
+        ))}
+        <section className="panel">
+          <button onClick={onStart}>Приступить к работе</button>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PalettePreview.tsx
+++ b/src/components/PalettePreview.tsx
@@ -1,8 +1,13 @@
 import { useSelector } from 'react-redux'
-import type {RootState} from '../store'
+import { useCallback } from 'react'
+import type { RootState } from '../store'
 
 export default function PalettePreview() {
   const colors = useSelector((state: RootState) => state.palette.colors)
+
+  const copy = useCallback((c: string) => {
+    void navigator.clipboard.writeText(c)
+  }, [])
 
   if (colors.length === 0) return null
 
@@ -11,14 +16,21 @@ export default function PalettePreview() {
       {colors.map((c) => (
         <div
           key={c}
-          style={{
-            background: c,
-            width: '40px',
-            height: '40px',
-            border: '1px solid #ccc',
-          }}
-          title={c}
-        />
+          onClick={() => copy(c)}
+          style={{ cursor: 'pointer', textAlign: 'center' }}
+        >
+          <div
+            style={{
+              background: c,
+              width: '60px',
+              height: '60px',
+              border: '1px solid #ccc',
+              marginBottom: '0.25rem',
+            }}
+            title={c}
+          />
+          <span style={{ fontSize: '0.75rem' }}>{c}</span>
+        </div>
       ))}
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -24,10 +24,7 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {
@@ -45,6 +42,27 @@ button {
   background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
+}
+
+/* landing page styles */
+.landing-container {
+  height: 100vh;
+  overflow: hidden;
+}
+
+.landing-sections {
+  display: flex;
+  height: 100%;
+}
+
+.panel {
+  flex: 0 0 100vw;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  padding: 2rem;
+  box-sizing: border-box;
 }
 button:hover {
   border-color: #646cff;

--- a/src/types/quantize.d.ts
+++ b/src/types/quantize.d.ts
@@ -1,0 +1,6 @@
+declare module 'quantize' {
+  export default function quantize(
+    pixels: number[][],
+    colorCount: number,
+  ): { palette(): [number, number, number][] } | undefined
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- create GSAP-powered landing page with horizontal scrolling feature tour
- show uploaded image preview and clickable palette swatches
- add type declarations and config fixes for clean build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce33baaec832eae8fb191d3147ea1